### PR TITLE
Set customEnvVariables in renovate.json

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ type renovateConfiguration struct {
 	VulnerabilityAlerts    vulnerabilityAlerts `json:"vulnerabilityAlerts"`
 	OsvVulnerabilityAlerts bool                `json:"osvVulnerabilityAlerts"`
 	DependencyDashboard    bool                `json:"dependencyDashboard"`
+	CustomEnvVariables     map[string]string   `json:"customEnvVariables"`
 }
 
 type packageRules struct {
@@ -461,6 +462,9 @@ func renderConfig(repoPath, mainBranch string, branchProps []branchProperties, d
 		},
 		OsvVulnerabilityAlerts: true,
 		DependencyDashboard:    false,
+		CustomEnvVariables: map[string]string{
+			"GOPRIVATE": "github.com/grafana",
+		},
 	}
 
 	outputPath := filepath.Join(gitHubDir, "renovate.json")


### PR DESCRIPTION
Set `customEnvVariables` in renovate.json as follows:

```json
"customEnvVariables": {
  "GOPRIVATE": "github.com/grafana"
}
```

This is to make Renovate support private Go dependencies.