### PR TITLE
Support configuring of unmaintained versions

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"go.yaml.in/yaml/v4"
+)
+
+type config struct {
+	// UnmaintainedVersions contains any major.minor versions that Renovate should not maintain.
+	UnmaintainedVersions []string `yaml:"unmaintained_versions"`
+}
+
+func readConfig(repoPath string) (config, error) {
+	p := filepath.Join(repoPath, ".generate-renovate-config.yml")
+	data, err := os.ReadFile(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return config{}, nil
+		}
+		return config{}, fmt.Errorf("read %q: %w", p, err)
+	}
+
+	var cfg config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return cfg, fmt.Errorf("unmarshal %q: %w", p, err)
+	}
+
+	return cfg, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/grafana/generate-renovate-config
 
 go 1.23.2
 
-require github.com/urfave/cli/v3 v3.6.0
+require (
+	github.com/urfave/cli/v3 v3.6.0
+	go.yaml.in/yaml/v4 v4.0.0-rc.3
+)

--- a/go.sum
+++ b/go.sum
@@ -6,5 +6,7 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/urfave/cli/v3 v3.6.0 h1:oIdArVjkdIXHWg3iqxgmqwQGC8NM0JtdgwQAj2sRwFo=
 github.com/urfave/cli/v3 v3.6.0/go.mod h1:ysVLtOEmg2tOy6PknnYVhDoouyC/6N42TMeoMzskhso=
+go.yaml.in/yaml/v4 v4.0.0-rc.3 h1:3h1fjsh1CTAPjW7q/EMe+C8shx5d8ctzZTrLcs/j8Go=
+go.yaml.in/yaml/v4 v4.0.0-rc.3/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Support configuring of unmaintained versions, so we can configure that the GEM 3.0 release branch should not be maintained (v2.17 will be the last GEM release).