### PR TITLE
Add helpers:pinGitHubActionDigests to extends

### DIFF
--- a/main.go
+++ b/main.go
@@ -573,7 +573,7 @@ func renderConfig(repoPath, mainBranch string, branchProps []branchProperties, o
 	}
 	cfg := renovateConfiguration{
 		Schema:       "https://docs.renovatebot.com/renovate-schema.json",
-		Extends:      []string{"config:recommended"},
+		Extends:      []string{"config:recommended", "helpers:pinGitHubActionDigests"},
 		BaseBranches: append([]string{mainBranch}, rlsBranches...),
 		PostUpdateOptions: []string{
 			"gomodTidy",


### PR DESCRIPTION
Make pin-maintenance of GitHub Action SHA digests explicit by extending Renovate's helpers:pinGitHubActionDigests preset, which sets pinDigests=true for action-typed deps. Catches future unpinned 'uses:' references and complements the recent SHA-pinning sweeps in grafana/backend-enterprise#12652 and grafana/mimir#15414.

Refs grafana/mimir-squad#3689