### PR TITLE
fix: sort replaced packages for stable matchPackageNames output

### DIFF
--- a/main.go
+++ b/main.go
@@ -369,6 +369,9 @@ func getBranchProperties(repoPath, branch string) (branchProperties, error) {
 		return branchProps, fmt.Errorf("failed to read %q: %w", goModPath, err)
 	}
 
+	// Sort for stable output regardless of go.mod source order.
+	slices.Sort(branchProps.replaced)
+
 	branchProps.goVersion, err = deduceGoVersion(repoPath)
 	return branchProps, err
 }


### PR DESCRIPTION
`getBranchProperties` appended replaced-module names in go.mod source order, which made `MatchPackageNames` in the generated Renovate config sensitive to purely cosmetic go.mod reorderings. Renovate treats `matchPackageNames` as a set, so the order has no semantic effect, but consumers running `make check-renovate` see CI failures whenever go.mod is reordered on a release branch (concretely: grafana/backend-enterprise#12813, where three replace directives flipped position on gem-release-2.17 and broke the check on every open PR).

Sort the slice after parsing so the output is stable.